### PR TITLE
refactor: add null to docblock for dateTime getter

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -804,7 +804,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
         }
         $script .= "
      *
-     * @param string \$format The date/time format string (either date()-style or strftime()-style).
+     * @param string|null \$format The date/time format string (either date()-style or strftime()-style).
      *				 If format is null, then the raw ".($useDateTime ? 'DateTime object' : 'unix timestamp integer')." will be returned.";
         if ($useDateTime) {
             $script .= "


### PR DESCRIPTION
## Description
This updates the generator of Models so that the docblocks for datetime getters are updated correctly.
`@param string $format` will now be `@param string|null $format`

and complete method will now be look like this
```
    /**
     * Get the [optionally formatted] temporal [last_login] column value.
     *
     *
     * @param string|null $format The date/time format string (either date()-style or strftime()-style).
     *				 If format is null, then the raw DateTime object will be returned.
     * @return mixed Formatted date/time value as string or DateTime object (if format is null), null if column is null, and 0 if column value is 0000-00-00 00:00:00
     * @throws PropelException - if unable to parse/validate the date/time value.
     */
    public function getLastLogin($format = 'Y-m-d H:i:s')
    {
       //*** code removed
    }
```


## Motivation and Context
closes #8

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [] I have ran all tests and none have failed.
- [] I have rebased the `develop` branch onto this branch (feature or hotfix).