### PR TITLE
refactor: adds different mutator for date column

### DIFF
--- a/generator/lib/builder/om/ObjectBuilder.php
+++ b/generator/lib/builder/om/ObjectBuilder.php
@@ -89,7 +89,9 @@ abstract class ObjectBuilder extends OMBuilder
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->isLobType()) {
                 $this->addLobMutator($script, $col);
-            } elseif ($col->getType() === PropelTypes::DATE || $col->getType() === PropelTypes::TIME || $col->getType() === PropelTypes::TIMESTAMP) {
+            } elseif ($col->getType() === PropelTypes::DATE) {
+                $this->addTemporalMutatorDate($script, $col);
+            } elseif ($col->getType() === PropelTypes::TIME || $col->getType() === PropelTypes::TIMESTAMP) {
                 $this->addTemporalMutator($script, $col);
             } elseif ($col->getType() === PropelTypes::OBJECT) {
                 $this->addObjectMutator($script, $col);


### PR DESCRIPTION
This will add a different mutator to the date columns.

Date, time and datatime field where all handled the same, 
but since the introduction of timezones, this is not desirable

with this pull request date field are and handled different.
If dates are given to propel in a dateTime object for a date column.
Only the date is important and not the time/timezone.

closes #14