### PR TITLE
fix: fixes issue with DATE and timezone conversion

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -1747,6 +1747,9 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
         $fmt = var_export($this->getTemporalFormatter($col), true);
 
         $script .= "
+        if (\$v instanceof \\DateTimeInterface) {
+            \$v = \$v->format('Y-m-d');
+        }
         \$dt = PropelDateTime::newInstance(\$v, null, '$dateTimeClass');
         if (\$this->$clo !== null || \$dt !== null) {
             \$currentDateAsString = (\$this->$clo !== null && \$tmpDt = new $dateTimeClass(\$this->$clo)) ? \$tmpDt->format($fmt) : null;


### PR DESCRIPTION
This pull request fixes a DATE issue with timezone conversion.

for example this test was failing

```php
    /**
     * Ensures setting DOB from a \DateTime (UTC) stores a date-only value and returns string when requested.
     *
     * Expectation: getDateOfBirth() returns '1980-01-01' as a string.
     */
    public function testSetsDateOfBirthFromDateTimeAndReturnsString()
    {
        $this->setupTestDatabase();

        $objEmployee = $this->getEmployeeCwJules();
        $objDateTime = new \DateTime('1980-01-01', new \DateTimeZone('UTC'));
        $objEmployee->setDateOfBirth($objDateTime);
        $objEmployee->save();

        $this->assertEquals('1980-01-01', $objEmployee->getDateOfBirth());
    }
```

closes #20